### PR TITLE
[BFLY-618] Renamed Interfaces And Added cancelOnRevert key in OrderResponse

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@firefly-exchange/firefly-client",
-  "version": "1.0.9",
+  "version": "1.0.10",
   "description": "Firefly client library for creating signed orders and placing on exchange.",
   "main": "dist/index.js",
   "scripts": {

--- a/src/exchange/sockets.ts
+++ b/src/exchange/sockets.ts
@@ -14,7 +14,7 @@ import {
   GetPositionResponse,
   GetUserTradesResponse,
   GetAccountDataResponse,
-  MiniTickerData,
+  MarketData,
 } from "../interfaces/routes";
 
 export class Sockets {
@@ -95,7 +95,7 @@ export class Sockets {
   };
 
   onMarketDataUpdate = (
-    cb: ({ marketData }: { marketData: MiniTickerData }) => void
+    cb: ({ marketData }: { marketData: MarketData }) => void
   ) => {
     this.socketInstance.on(SOCKET_EVENTS.MarketDataUpdateKey, cb);
   };

--- a/src/fireflyClient.ts
+++ b/src/fireflyClient.ts
@@ -53,8 +53,8 @@ import {
   GetMarketRecentTradesRequest,
   GetMarketRecentTradesResponse,
   GetCandleStickRequest,
-  MarketInfo,
-  MiniTickerData,
+  ExchangeInfo,
+  MarketData,
   MarketMeta,
   StatusResponse,
   AuthorizeHashResponse,
@@ -671,10 +671,10 @@ export class FireflyClient {
   /**
    * Gets publically available market info about market(s)
    * @param symbol (optional) market symbol get information about, by default fetches info on all available markets
-   * @returns MarketInfo or MarketInfo[] in case no market was provided as input
+   * @returns ExchangeInfo or ExchangeInfo[] in case no market was provided as input
    */
   async getExchangeInfo(symbol?: MarketSymbol) {
-    const response = await this.apiService.get<MarketInfo>(
+    const response = await this.apiService.get<ExchangeInfo>(
       SERVICE_URLS.MARKET.EXCHANGE_INFO,
       { symbol }
     );
@@ -682,12 +682,12 @@ export class FireflyClient {
   }
 
   /**
-   * Gets MiniTickerData data for market(s)
+   * Gets MarketData data for market(s)
    * @param symbol (optional) market symbol get information about, by default fetches info on all available markets
-   * @returns MiniTickerData or MiniTickerData[] in case no market was provided as input
+   * @returns MarketData or MarketData[] in case no market was provided as input
    */
   async getMarketData(symbol?: MarketSymbol) {
-    const response = await this.apiService.get<MiniTickerData>(
+    const response = await this.apiService.get<MarketData>(
       SERVICE_URLS.MARKET.MARKET_DATA,
       { symbol }
     );

--- a/src/interfaces/routes.ts
+++ b/src/interfaces/routes.ts
@@ -81,6 +81,7 @@ interface OrderResponse {
   makerFee: string;
   takerFee: string;
   openQty: string;
+  cancelOnRevert?: boolean;
 }
 
 export interface GetOrderResponse extends OrderResponse {
@@ -244,7 +245,7 @@ export interface GetCandleStickRequest {
 }
 
 /* Market Endpoints */
-export interface MarketInfo {
+export interface ExchangeInfo {
   symbol: MarketSymbol;
   maintMarginReq: string;
   inititalMarginReq: string;
@@ -269,7 +270,7 @@ export interface MarketInfo {
   maxAllowedOrderQuantityRules: OrderQuantityRules[]
 }
 
-export interface MiniTickerData {
+export interface MarketData {
   symbol: MarketSymbol;
   bestAskPrice: string;
   bestAskQty: string;


### PR DESCRIPTION
- Added cancelOnRevert?: boolean; in OrderResponse interface

- Renamed MarketInfo to ExchangeInfo

- Renamed MiniTickerData to MarketInfo or MarketData 