### PR TITLE
Kulsoom/bfly 449 support missing params in order creation

### DIFF
--- a/examples/10.place-signed-order.ts
+++ b/examples/10.place-signed-order.ts
@@ -3,7 +3,7 @@
  */
 
 /* eslint-disable no-console */
-import { Networks, FireflyClient, MARKET_SYMBOLS, ORDER_SIDE } from "../index";
+import { Networks, FireflyClient, MARKET_SYMBOLS, ORDER_SIDE, ORDER_TYPE } from "../index";
 
 async function main() {
   // no gas fee is required to create order signature.
@@ -18,9 +18,10 @@ async function main() {
   // will create a signed order to sell 0.1 DOT at MARKET price
   const signedOrder = await client.createSignedOrder({
     symbol: MARKET_SYMBOLS.DOT, // asset to be traded
-    price: 0, // 0 implies market order anything > 0 is limit order
+    price: 0, // 0 implies market order
     quantity: 0.1, // the amount of asset to trade
     side: ORDER_SIDE.SELL, // buy or sell
+    orderType: ORDER_TYPE.MARKET
   });
 
   const response = await client.placeSignedOrder(signedOrder);

--- a/examples/11.post-order.ts
+++ b/examples/11.post-order.ts
@@ -4,7 +4,7 @@
  */
 
 /* eslint-disable no-console */
-import { Networks, FireflyClient, MARKET_SYMBOLS, ORDER_SIDE } from "../index";
+import { Networks, FireflyClient, MARKET_SYMBOLS, ORDER_SIDE, ORDER_TYPE } from "../index";
 
 async function main() {
   // no gas fee is required to create order signature.
@@ -22,6 +22,7 @@ async function main() {
     price: 11,
     quantity: 0.5,
     side: ORDER_SIDE.BUY,
+    orderType: ORDER_TYPE.LIMIT
   });
 
   console.log(response.data);

--- a/examples/12-create-cancellation-signature.ts
+++ b/examples/12-create-cancellation-signature.ts
@@ -3,7 +3,7 @@
  */
 
 /* eslint-disable no-console */
-import { Networks, FireflyClient, MARKET_SYMBOLS, ORDER_SIDE } from "../index";
+import { Networks, FireflyClient, MARKET_SYMBOLS, ORDER_SIDE, ORDER_TYPE } from "../index";
 
 async function main() {
   const dummyAccountKey =
@@ -20,6 +20,7 @@ async function main() {
     price: 15,
     quantity: 0.5,
     side: ORDER_SIDE.SELL,
+    orderType: ORDER_TYPE.LIMIT
   });
 
   // create signature

--- a/examples/13-place-cancel-order.ts
+++ b/examples/13-place-cancel-order.ts
@@ -3,7 +3,7 @@
  */
 
 /* eslint-disable no-console */
-import { Networks, FireflyClient, MARKET_SYMBOLS, ORDER_SIDE } from "../index";
+import { Networks, FireflyClient, MARKET_SYMBOLS, ORDER_SIDE, ORDER_TYPE } from "../index";
 
 async function main() {
   const dummyAccountKey =
@@ -20,6 +20,7 @@ async function main() {
     price: 15,
     quantity: 0.5,
     side: ORDER_SIDE.SELL,
+    orderType: ORDER_TYPE.LIMIT
   });
 
   // create signature

--- a/examples/14-post-cancel-order.ts
+++ b/examples/14-post-cancel-order.ts
@@ -3,7 +3,7 @@
  */
 
 /* eslint-disable no-console */
-import { Networks, FireflyClient, MARKET_SYMBOLS, ORDER_SIDE } from "../index";
+import { Networks, FireflyClient, MARKET_SYMBOLS, ORDER_SIDE, ORDER_TYPE } from "../index";
 
 async function main() {
   const dummyAccountKey =
@@ -20,6 +20,7 @@ async function main() {
     price: 15,
     quantity: 0.5,
     side: ORDER_SIDE.SELL,
+    orderType: ORDER_TYPE.LIMIT
   });
 
   // posts order for cancellation on exchange

--- a/examples/15-cancel-all-open-orders.ts
+++ b/examples/15-cancel-all-open-orders.ts
@@ -3,7 +3,7 @@
  */
 
 /* eslint-disable no-console */
-import { Networks, FireflyClient, MARKET_SYMBOLS, ORDER_SIDE } from "../index";
+import { Networks, FireflyClient, MARKET_SYMBOLS, ORDER_SIDE, ORDER_TYPE } from "../index";
 
 async function main() {
   const dummyAccountKey =
@@ -20,6 +20,7 @@ async function main() {
     price: 15,
     quantity: 0.5,
     side: ORDER_SIDE.SELL,
+    orderType: ORDER_TYPE.LIMIT
   });
 
   await client.postOrder({
@@ -27,6 +28,7 @@ async function main() {
     price: 15,
     quantity: 0.5,
     side: ORDER_SIDE.SELL,
+    orderType: ORDER_TYPE.LIMIT
   });
 
   // cancels all open order

--- a/examples/21-listening-events.ts
+++ b/examples/21-listening-events.ts
@@ -9,6 +9,7 @@ import {
   MARKET_SYMBOLS,
   ORDER_SIDE,
   PlaceOrderResponse,
+  ORDER_TYPE,
 } from "../index";
 
 async function main() {
@@ -43,6 +44,7 @@ async function main() {
     price: 0,
     quantity: 0.5,
     side: ORDER_SIDE.BUY,
+    orderType: ORDER_TYPE.MARKET
   });
 }
 

--- a/examples/9.create-signed-order.ts
+++ b/examples/9.create-signed-order.ts
@@ -5,7 +5,7 @@
  */
 
 /* eslint-disable no-console */
-import { Networks, FireflyClient, MARKET_SYMBOLS, ORDER_SIDE } from "../index";
+import { Networks, FireflyClient, MARKET_SYMBOLS, ORDER_SIDE, ORDER_TYPE } from "../index";
 
 async function main() {
   // no gas fee is required to create order signature.
@@ -24,6 +24,7 @@ async function main() {
       price: 0,
       quantity: 0.1,
       side: ORDER_SIDE.SELL,
+      orderType: ORDER_TYPE.MARKET
     });
   } catch (e) {
     console.log("Error:", e);
@@ -32,9 +33,10 @@ async function main() {
   // will create a signed order to sell 0.1 DOT at MARKET price
   const signedOrder = await client.createSignedOrder({
     symbol: MARKET_SYMBOLS.DOT, // asset to be traded
-    price: 0, // 0 implies market order anything > 0 is limit order
+    price: 0, // 0 implies market order
     quantity: 0.1, // the amount of asset to trade
     side: ORDER_SIDE.SELL, // buy or sell
+    orderType: ORDER_TYPE.MARKET
   });
 
   console.log("Signed Order Created:", signedOrder);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@firefly-exchange/firefly-client",
-  "version": "1.0.23",
+  "version": "1.0.24",
   "description": "Firefly client library for creating signed orders and placing on exchange.",
   "main": "dist/index.js",
   "scripts": {

--- a/src/fireflyClient.ts
+++ b/src/fireflyClient.ts
@@ -392,6 +392,7 @@ export class FireflyClient {
       salt: order.salt.toNumber(),
       expiration: order.expiration.toNumber(),
       orderSignature: signedOrder.typedSignature,
+      orderType: params.orderType
     };
   }
 
@@ -407,7 +408,7 @@ export class FireflyClient {
       {
         symbol: params.symbol,
         userAddress: this.getPublicAddress().toLocaleLowerCase(),
-        orderType: params.price === 0 ? ORDER_TYPE.MARKET : ORDER_TYPE.LIMIT,
+        orderType: params.orderType,
         price: toBigNumberStr(params.price),
         quantity: toBigNumberStr(params.quantity),
         leverage: toBigNumberStr(params.leverage),
@@ -418,6 +419,7 @@ export class FireflyClient {
         orderSignature: params.orderSignature,
         timeInForce: params.timeInForce || TIME_IN_FORCE.GOOD_TILL_TIME,
         postOnly: params.postOnly || false,
+        clientId: params.clientId ? `firefly-client: ${params.clientId}` : "firefly-client"
       }
     );
 
@@ -435,6 +437,7 @@ export class FireflyClient {
       ...signedOrder,
       timeInForce: params.timeInForce,
       postOnly: params.postOnly,
+      clientId: params.clientId,
     });
 
     return response;
@@ -924,7 +927,7 @@ export class FireflyClient {
   private createOrderToSign(params: OrderSignatureRequest): Order {
     const expiration = new Date();
     //MARKET ORDER - set expiration of 1 minute
-    if (params.price === 0){
+    if (params.orderType === ORDER_TYPE.MARKET){
       expiration.setMinutes(expiration.getMinutes() + 1);
     }
     //LIMIT ORDER - set expiration of 1 month

--- a/src/interfaces/routes.ts
+++ b/src/interfaces/routes.ts
@@ -28,6 +28,7 @@ export interface RequiredOrderFields {
   price: number; // price at which to place order. Will be zero for a market order
   quantity: number; // quantity/size of order
   side: ORDER_SIDE; // BUY/SELL
+  orderType: ORDER_TYPE; //MARKET/LIMIT
 }
 
 export interface OrderSignatureRequest extends RequiredOrderFields {
@@ -48,11 +49,13 @@ export interface OrderSignatureResponse extends RequiredOrderFields {
 export interface PlaceOrderRequest extends OrderSignatureResponse {
   timeInForce?: TIME_IN_FORCE; // FOK/IOC/GTT by default all orders are GTT
   postOnly?: boolean; // true/false, default is true
+  clientId?: string;
 }
 
 export interface PostOrderRequest extends OrderSignatureRequest {
   timeInForce?: TIME_IN_FORCE;
   postOnly?: boolean;
+  clientId?: string;
 }
 
 interface OrderResponse {

--- a/tests/fireflyClient.test.ts
+++ b/tests/fireflyClient.test.ts
@@ -10,6 +10,7 @@ import {
   bnStrToBaseNumber,
   MinifiedCandleStick,
   BigNumber,
+  ORDER_TYPE,
 } from "@firefly-exchange/library";
 
 import {
@@ -189,6 +190,7 @@ describe("FireflyClient", () => {
           price: 0,
           quantity: 0.1,
           side: ORDER_SIDE.SELL,
+          orderType: ORDER_TYPE.MARKET
         })
       ).to.be.eventually.rejectedWith(
         "Provided Market Symbol(BTC-PERP) is not added to client library"
@@ -201,6 +203,7 @@ describe("FireflyClient", () => {
         price: 0,
         quantity: 0.1,
         side: ORDER_SIDE.SELL,
+        orderType: ORDER_TYPE.MARKET
       });
 
       expect(signedOrder.leverage).to.be.equal(1);
@@ -214,7 +217,8 @@ describe("FireflyClient", () => {
         price: 11,
         quantity: 0.5,
         side: ORDER_SIDE.SELL,
-        leverage: 3
+        leverage: 3,
+        orderType: ORDER_TYPE.LIMIT
       });
 
       const response = await client.placeSignedOrder({ ...signedOrder });                  
@@ -227,7 +231,8 @@ describe("FireflyClient", () => {
         price: 0,
         quantity: 0.5,
         side: ORDER_SIDE.SELL,
-        leverage: 3
+        leverage: 3,
+        orderType: ORDER_TYPE.MARKET
       });
       const response = await client.placeSignedOrder({ ...signedOrder });      
       expect(response.ok).to.be.equal(true);
@@ -239,7 +244,9 @@ describe("FireflyClient", () => {
         price: 11,
         quantity: 0.5,
         side: ORDER_SIDE.BUY,
-        leverage: 3
+        leverage: 3,
+        orderType: ORDER_TYPE.LIMIT,
+        clientId: "Test limit order"
       });
       
       expect(response.ok).to.be.equal(true);
@@ -257,9 +264,13 @@ describe("FireflyClient", () => {
         price: 11,
         quantity: 0.5,
         side: ORDER_SIDE.SELL,
-        leverage: 3
+        leverage: 3,
+        orderType: ORDER_TYPE.LIMIT
       });
-      const response = await client.placeSignedOrder({ ...signedOrder });
+      const response = await client.placeSignedOrder({ 
+        ...signedOrder,
+        clientId: "test cancel order" 
+      });
       
       const cancelSignature = await client.createOrderCancellationSignature({
         symbol: MARKET_SYMBOLS.DOT,
@@ -281,7 +292,8 @@ describe("FireflyClient", () => {
         price: 11,
         quantity: 0.5,
         side: ORDER_SIDE.SELL,
-        leverage: 3
+        leverage: 3,
+        orderType: ORDER_TYPE.LIMIT
       });
       const response = await client.placeSignedOrder({ ...signedOrder });
 
@@ -303,7 +315,8 @@ describe("FireflyClient", () => {
         price: 15,
         quantity: 0.5,
         side: ORDER_SIDE.SELL,
-        leverage: 3
+        leverage: 3,
+        orderType: ORDER_TYPE.LIMIT
       });
       expect(response.ok).to.be.equal(true);
 
@@ -556,7 +569,8 @@ describe("FireflyClient", () => {
           price: 15,
           quantity: 0.5,
           side: ORDER_SIDE.SELL,
-          leverage: 3
+          leverage: 3,
+          orderType: ORDER_TYPE.LIMIT
         });
       });
     });
@@ -580,7 +594,8 @@ describe("FireflyClient", () => {
           price: 0,
           quantity: 0.5,
           side: ORDER_SIDE.SELL,
-          leverage: 3
+          leverage: 3,
+          orderType: ORDER_TYPE.MARKET
         });        
       });
     });
@@ -600,7 +615,8 @@ describe("FireflyClient", () => {
           price: 12,
           quantity: 0.5,
           side: ORDER_SIDE.SELL,
-          leverage: 3
+          leverage: 3,
+          orderType: ORDER_TYPE.LIMIT
         });
       });
     });
@@ -622,7 +638,8 @@ describe("FireflyClient", () => {
           price: 0,
           quantity: 0.5,
           side: ORDER_SIDE.BUY,
-          leverage: 3
+          leverage: 3,
+          orderType: ORDER_TYPE.MARKET
         });
       });
     });
@@ -643,7 +660,8 @@ describe("FireflyClient", () => {
           price: 0,
           quantity: 0.5,
           side: ORDER_SIDE.BUY,
-          leverage: 3
+          leverage: 3,
+          orderType: ORDER_TYPE.MARKET
         });
       });
     });
@@ -669,7 +687,8 @@ describe("FireflyClient", () => {
           price: 0,
           quantity: 0.5,
           side: ORDER_SIDE.BUY,
-          leverage: 3
+          leverage: 3,
+          orderType: ORDER_TYPE.MARKET
         });
       });
     });


### PR DESCRIPTION
- added `clientId` and `orderType` param for order creation
- fixed testcases and examples
- bumped version