### PR TITLE
[BFLY 1031] Fix Cancel Order

### DIFF
--- a/src/fireflyClient.ts
+++ b/src/fireflyClient.ts
@@ -518,7 +518,6 @@ export class FireflyClient {
       SERVICE_URLS.ORDERS.ORDERS_HASH,
       {
         symbol: params.symbol,
-        userAddress: this.getPublicAddress(),
         orderHashes: params.hashes,
         cancelSignature: params.signature,
       },


### PR DESCRIPTION
dAPI recently updated the delete order path's request payload to more strictly enforce types causing this client call to break - client had been sending an unnecessary field  